### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 HackerNews CLI
 ==============
 
-[![Latest Version](https://pypip.in/version/hackernews-cli/badge.svg)](https://pypi.python.org/pypi/hackernews-cli/)
+[![Latest Version](https://img.shields.io/pypi/v/hackernews-cli.svg
 [Docs](http://pythonhosted.org//hackernews-cli/)
 
 For presentation purpose.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 HackerNews CLI
 ==============
 
-[![Latest Version](https://img.shields.io/pypi/v/hackernews-cli.svg
+[![Latest Version](https://img.shields.io/pypi/v/hackernews-cli.svg)](https://pypi.python.org/pypi/hackernews-cli/)
 [Docs](http://pythonhosted.org//hackernews-cli/)
 
 For presentation purpose.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20hackernews-cli))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `hackernews-cli`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.